### PR TITLE
fix: Don't consider previous info when getting context for shared info

### DIFF
--- a/Plugins/DialogueExporter/Services/VoiceSheets/ExportVoiceSheets.cs
+++ b/Plugins/DialogueExporter/Services/VoiceSheets/ExportVoiceSheets.cs
@@ -1,4 +1,4 @@
-﻿using CreationEditor;
+using CreationEditor;
 using CreationEditor.Services.DataSource;
 using CreationEditor.Services.Environment;
 using CreationEditor.Services.Mutagen.Mod;
@@ -192,6 +192,7 @@ public class ExportVoiceSheets(
                     var results = referenceService.GetRecordReferences(responses)
                         .Select(reference => linkCache.TryResolveSimpleContext<IDialogResponsesGetter>(reference.FormKey, out var context) ? context : null)
                         .WhereNotNull()
+                        .Where(r => r.Record.ResponseData.Equals(responses))
                         .Select(r => {
                             if (r.Parent?.Record is not IDialogTopicGetter t) return (string.Empty, null, null);
                             if (topic.Quest.TryResolve(linkCache) is not {} q) return (string.Empty, null, null);


### PR DESCRIPTION
GetContext recursively checked every shared info in a topic due to them being referenced by PreviousInfo. This resulted in both incorrect context for shared responses and very slow (either O(2^n) or O(n!)) loop